### PR TITLE
fix: Fix the mechanism for killing child processes when CTRL+C is used

### DIFF
--- a/makim/makim.py
+++ b/makim/makim.py
@@ -59,6 +59,7 @@ class Makim(PrintPlugin):
             _bg_exc=False,
             _no_err=True,
             _env=os.environ,
+            _new_session=True,
         )
 
         try:
@@ -68,7 +69,7 @@ class Makim(PrintPlugin):
             os._exit(1)
         except KeyboardInterrupt:
             pid = p.pid
-            p.kill()
+            p.kill_group()
             self._print_error(f'[EE] Process {pid} killed.')
             os._exit(1)
 


### PR DESCRIPTION
## Pull Request description
<!-- Describe the purpose of your PR and the changes you have made. -->

Currently, when CTRL+C is pressed the child processes are not killed. 
This PR aims to fix this problem, killing the entire group for that process.

<!-- Which issue this PR aims to resolve or fix? E.g.:
Solving issue #004
-->

## How to test these changes

<!-- Example:

* run `$ abc -p 1234`
* open the web browser with url localhost:1234
* ...
-->

* ```...```

<!-- Modify the options to suit your project. -->
## Pull Request checklists

This PR is a:
- [ ] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:
- [ ] it includes tests.
- [ ] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:
- [ ] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more complexity.
- [ ] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->

<!-- Add any other extra information that would help to understand the changes proposed by this PR -->

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
