### PR TITLE
feat: Change the default template tag delimiter

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,11 +1,11 @@
-* makim version:
-* Python version:
-* Operating System:
+- makim version:
+- Python version:
+- Operating System:
 
 ### Description
 
-Describe what you were trying to get done.
-Tell us what happened, what went wrong, and what you expected to happen.
+Describe what you were trying to get done. Tell us what happened, what went
+wrong, and what you expected to happen.
 
 ### What I Did
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,5 @@
 ## Pull Request description
+
 <!-- Describe the purpose of your PR and the changes you have made. -->
 
 <!-- Which issue this PR aims to resolve or fix? E.g.:
@@ -14,17 +15,20 @@ Solving issue #004
 * ...
 -->
 
-* ```...```
+- `...`
 
 <!-- Modify the options to suit your project. -->
+
 ## Pull Request checklists
 
 This PR is a:
+
 - [ ] bug-fix
 - [ ] new feature
 - [ ] maintenance
 
 About this PR:
+
 - [ ] it includes tests.
 - [ ] the tests are executed on CI.
 - [ ] the tests generate log file(s) (path).
@@ -32,8 +36,10 @@ About this PR:
 - [ ] this PR requires a project documentation update.
 
 Author's checklist:
+
 - [ ] I have reviewed the changes and it contains no misspelling.
-- [ ] The code is well commented, especially in the parts that contain more complexity.
+- [ ] The code is well commented, especially in the parts that contain more
+      complexity.
 - [ ] New and old tests passed locally.
 
 ## Additional information

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,9 +2,9 @@ name: build
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   check-branch:
@@ -33,14 +33,14 @@ jobs:
     strategy:
       matrix:
         python_version:
-          - '3.8.1'
-          - '3.9'
-          - '3.10'
-          - '3.11'
-          - '3.12'
+          - "3.8.1"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
         os:
-          - 'ubuntu'
-          - 'macos'
+          - "ubuntu"
+          - "macos"
           # poetry is failing on windows: https://github.com/python-poetry/poetry/issues/1031
           # - 'windows'
 
@@ -56,97 +56,97 @@ jobs:
       cancel-in-progress: true
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Install MacOS extra tools and add extra setup
-      if: ${{ matrix.os == 'macos' }}
-      run: |
-        sudo mkdir -p /tmp
-        sudo chmod 777 /tmp
+      - name: Install MacOS extra tools and add extra setup
+        if: ${{ matrix.os == 'macos' }}
+        run: |
+          sudo mkdir -p /tmp
+          sudo chmod 777 /tmp
 
-        brew install gnu-sed
-        echo 'export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"' >> ~/.bashrc
-        echo 'export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"' >> ~/.bash_profile
-        gsed -i s:/tmp:/private/tmp:g tests/smoke/.makim-working-directory-absolute-path.yaml
-        gsed -i s:/tmp:/private/tmp:g tests/smoke/.makim-working-directory-no-path.yaml
-        gsed -i s:/tmp:/private/tmp:g tests/smoke/.makim-working-directory-relative-path.yaml
+          brew install gnu-sed
+          echo 'export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"' >> ~/.bashrc
+          echo 'export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"' >> ~/.bash_profile
+          gsed -i s:/tmp:/private/tmp:g tests/smoke/.makim-working-directory-absolute-path.yaml
+          gsed -i s:/tmp:/private/tmp:g tests/smoke/.makim-working-directory-no-path.yaml
+          gsed -i s:/tmp:/private/tmp:g tests/smoke/.makim-working-directory-relative-path.yaml
 
-    - name: Prepare conda environment (windows)
-      if: ${{ matrix.os == 'windows' }}
-      run: |
-        $env:Path += ";C:\Program Files\Git\usr\bin"
-        sed -i s/python\ 3\.8/python\ ${{ matrix.python_version }}/ conda/dev.yaml
-        cat conda/dev.yaml
+      - name: Prepare conda environment (windows)
+        if: ${{ matrix.os == 'windows' }}
+        run: |
+          $env:Path += ";C:\Program Files\Git\usr\bin"
+          sed -i s/python\ 3\.8/python\ ${{ matrix.python_version }}/ conda/dev.yaml
+          cat conda/dev.yaml
 
-    - name: Prepare conda environment
-      if: ${{ matrix.os != 'windows' }}
-      run: |
-        sed -i s/python\ 3\.8\.1/python\ ${{ matrix.python_version }}/ conda/dev.yaml
-        cat conda/dev.yaml
+      - name: Prepare conda environment
+        if: ${{ matrix.os != 'windows' }}
+        run: |
+          sed -i s/python\ 3\.8\.1/python\ ${{ matrix.python_version }}/ conda/dev.yaml
+          cat conda/dev.yaml
 
-    - uses: conda-incubator/setup-miniconda@v3
-      with:
-        miniforge-version: latest
-        environment-file: conda/dev.yaml
-        channels: conda-forge,nodefaults
-        activate-environment: makim
-        auto-update-conda: true
-        conda-solver: libmamba
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-version: latest
+          environment-file: conda/dev.yaml
+          channels: conda-forge,nodefaults
+          activate-environment: makim
+          auto-update-conda: true
+          conda-solver: libmamba
 
-    - name: Check Poetry lock
-      run: poetry check
+      - name: Check Poetry lock
+        run: poetry check
 
-    - name: Install dependencies
-      run: |
-        poetry config virtualenvs.create false
-        poetry install
+      - name: Install dependencies
+        run: |
+          poetry config virtualenvs.create false
+          poetry install
 
-    - name: Run smoke tests using simple makim file
-      run: makim smoke-tests.simple
+      - name: Run smoke tests using simple makim file
+        run: makim smoke-tests.simple
 
-    - name: Run smoke tests using complex makim file
-      run: makim smoke-tests.complex
+      - name: Run smoke tests using complex makim file
+        run: makim smoke-tests.complex
 
-    - name: Run smoke tests using makim and containers-sugar
-      if: ${{ matrix.os != 'macos' }}
-      run: makim smoke-tests.containers
+      - name: Run smoke tests using makim and containers-sugar
+        if: ${{ matrix.os != 'macos' }}
+        run: makim smoke-tests.containers
 
-    - name: Run smoke tests using different interpreters
-      run: makim smoke-tests.shell-app
+      - name: Run smoke tests using different interpreters
+        run: makim smoke-tests.shell-app
 
-    - name: Run smoke tests using unittest makim file
-      run: makim smoke-tests.unittest
+      - name: Run smoke tests using unittest makim file
+        run: makim smoke-tests.unittest
 
-    - name: Run smoke test using bash
-      run: makim smoke-tests.bash
+      - name: Run smoke test using bash
+        run: makim smoke-tests.bash
 
-    - name: Run smoke test for variable envs
-      run: makim smoke-tests.vars-env
+      - name: Run smoke test for variable envs
+        run: makim smoke-tests.vars-env
 
-    - name: Run smoke test for variables
-      run: makim smoke-tests.test-vars
+      - name: Run smoke test for variables
+        run: makim smoke-tests.test-vars
 
-    - name: Run smoke test for working-directory-absolute-path
-      run:  makim smoke-tests.working-directory-absolute-path
+      - name: Run smoke test for working-directory-absolute-path
+        run: makim smoke-tests.working-directory-absolute-path
 
-    - name: Run smoke test for working-directory-no-path
-      run:  makim smoke-tests.working-directory-no-path
+      - name: Run smoke test for working-directory-no-path
+        run: makim smoke-tests.working-directory-no-path
 
-    - name: Run smoke test for working-directory-relative-path
-      run: makim smoke-tests.working-directory-relative-path
+      - name: Run smoke test for working-directory-relative-path
+        run: makim smoke-tests.working-directory-relative-path
 
-    - name: Run unit tests
-      run: makim tests.unittest
+      - name: Run unit tests
+        run: makim tests.unittest
 
-    - name: Semantic Release PR Title Check
-      uses: osl-incubator/semantic-release-pr-title-check@v1.4.1
-      if: success() || failure()
-      with:
-        convention-name: conventionalcommits
+      - name: Semantic Release PR Title Check
+        uses: osl-incubator/semantic-release-pr-title-check@v1.4.1
+        if: success() || failure()
+        with:
+          convention-name: conventionalcommits
 
-    - name: Setup tmate session
-      if: "${{ failure() && (contains(github.event.pull_request.labels.*.name, 'ci:enable-debugging')) }}"
-      uses: mxschmitt/action-tmate@v3
+      - name: Setup tmate session
+        if: "${{ failure() && (contains(github.event.pull_request.labels.*.name, 'ci:enable-debugging')) }}"
+        uses: mxschmitt/action-tmate@v3
 
   linter-and-docs:
     needs: check-branch
@@ -162,31 +162,31 @@ jobs:
       cancel-in-progress: true
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - uses: conda-incubator/setup-miniconda@v3
-      with:
-        miniforge-version: latest
-        environment-file: conda/dev.yaml
-        channels: conda-forge,nodefaults
-        activate-environment: makim
-        auto-update-conda: true
-        conda-solver: libmamba
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-version: latest
+          environment-file: conda/dev.yaml
+          channels: conda-forge,nodefaults
+          activate-environment: makim
+          auto-update-conda: true
+          conda-solver: libmamba
 
-    - name: Install dependencies
-      run: |
-        poetry config virtualenvs.create false
-        poetry install
+      - name: Install dependencies
+        run: |
+          poetry config virtualenvs.create false
+          poetry install
 
-    - name: Test documentation generation
-      run: makim docs.build
+      - name: Test documentation generation
+        run: makim docs.build
 
-    - name: Run style checks
-      if: success() || failure()
-      run: |
-        pre-commit install
-        makim tests.linter
+      - name: Run style checks
+        if: success() || failure()
+        run: |
+          pre-commit install
+          makim tests.linter
 
-    - name: Setup tmate session
-      if: "${{ failure() && (contains(github.event.pull_request.labels.*.name, 'ci:enable-debugging')) }}"
-      uses: mxschmitt/action-tmate@v3
+      - name: Setup tmate session
+        if: "${{ failure() && (contains(github.event.pull_request.labels.*.name, 'ci:enable-debugging')) }}"
+        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,9 +3,9 @@ name: Release
 on:
   workflow_dispatch:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}

--- a/.makim.yaml
+++ b/.makim.yaml
@@ -49,12 +49,12 @@ groups:
     targets:
       ci:
         help: Run semantic release on CI
-        run: {{ vars.app }} --ci
+        run: ${{ vars.app }} --ci
 
       dry:
         help: Run semantic release in dry-run mode
         run: |
-          {{ vars.app }} --dry-run
+          ${{ vars.app }} --dry-run
           poetry build
           poetry publish --dry-run
 
@@ -103,7 +103,7 @@ groups:
           MAKIM_FILE: ./tests/smoke/.makim-simple.yaml
         shell: bash
         run: |
-          export VERBOSE_FLAG='{{ "--verbose" if args.verbose_mode else "" }}'
+          export VERBOSE_FLAG='${{ "--verbose" if args.verbose_mode else "" }}'
           makim $VERBOSE_FLAG --file $MAKIM_FILE --help
           makim $VERBOSE_FLAG --file $MAKIM_FILE --version
           makim $VERBOSE_FLAG --file $MAKIM_FILE default.clean
@@ -120,7 +120,7 @@ groups:
             action: store_true
         shell: bash
         run: |
-          export VERBOSE_FLAG='{{ "--verbose" if args.verbose_mode else "" }}'
+          export VERBOSE_FLAG='${{ "--verbose" if args.verbose_mode else "" }}'
           makim $VERBOSE_FLAG --file $MAKIM_FILE --help
           makim $VERBOSE_FLAG --file $MAKIM_FILE --version
           makim $VERBOSE_FLAG --file $MAKIM_FILE default.lint
@@ -165,7 +165,7 @@ groups:
             action: store_true
         shell: bash
         run: |
-          export VERBOSE_FLAG='{{ "--verbose" if args.verbose_mode else "" }}'
+          export VERBOSE_FLAG='${{ "--verbose" if args.verbose_mode else "" }}'
           cd ./tests/smoke
           makim $VERBOSE_FLAG --file $MAKIM_FILE containers.run
 
@@ -182,7 +182,7 @@ groups:
           MAKIM_FILE: tests/smoke/.makim-interpreters.yaml
         shell: bash
         run: |
-          export VERBOSE_FLAG='{{ "--verbose" if args.verbose_mode else "" }}'
+          export VERBOSE_FLAG='${{ "--verbose" if args.verbose_mode else "" }}'
           export MAKIM_FILE="$(pwd)/${MAKIM_FILE}"
           makim $VERBOSE_FLAG --file $MAKIM_FILE main.all
 
@@ -197,7 +197,7 @@ groups:
           MAKIM_FILE: ./tests/smoke/.makim-unittest.yaml
         shell: bash
         run: |
-          export VERBOSE_FLAG='{{ "--verbose" if args.verbose_mode else "" }}'
+          export VERBOSE_FLAG='${{ "--verbose" if args.verbose_mode else "" }}'
           makim $VERBOSE_FLAG --file $MAKIM_FILE --help
           makim $VERBOSE_FLAG --file $MAKIM_FILE --version
           makim $VERBOSE_FLAG --file $MAKIM_FILE tests.test-1
@@ -220,7 +220,7 @@ groups:
           MAKIM_FILE: ./tests/smoke/.makim-env.yaml
         shell: bash
         run: |
-          export VERBOSE_FLAG='{{ "--verbose" if args.verbose_mode else "" }}'
+          export VERBOSE_FLAG='${{ "--verbose" if args.verbose_mode else "" }}'
           makim $VERBOSE_FLAG --file $MAKIM_FILE --help
           makim $VERBOSE_FLAG --file $MAKIM_FILE --version
           makim $VERBOSE_FLAG --file $MAKIM_FILE global-scope.test-var-env-file
@@ -244,7 +244,7 @@ groups:
           MAKIM_FILE: ./tests/smoke/.makim-vars.yaml
         shell: bash
         run: |
-          export VERBOSE_FLAG='{{ "--verbose" if args.verbose_mode else "" }}'
+          export VERBOSE_FLAG='${{ "--verbose" if args.verbose_mode else "" }}'
           makim $VERBOSE_FLAG --file $MAKIM_FILE vars-group.vars-target
 
       bash:
@@ -256,7 +256,7 @@ groups:
             type: bool
             action: store_true
         run: |
-          export VERBOSE_FLAG='{{ "--verbose" if args.verbose_mode else "" }}'
+          export VERBOSE_FLAG='${{ "--verbose" if args.verbose_mode else "" }}'
           makim $VERBOSE_FLAG --file tests/smoke/.makim-bash-main-scope.yaml main-scope.test
           makim $VERBOSE_FLAG --file tests/smoke/.makim-bash-group-scope.yaml group-scope.test
           makim $VERBOSE_FLAG --file tests/smoke/.makim-bash-target-scope.yaml target-scope.test
@@ -274,7 +274,7 @@ groups:
           MAKIM_FILE: tests/smoke/.makim-working-directory-absolute-path.yaml
         shell: bash
         run: |
-          export VERBOSE_FLAG='{{ "--verbose" if args.verbose_mode else "" }}'
+          export VERBOSE_FLAG='${{ "--verbose" if args.verbose_mode else "" }}'
           makim $VERBOSE_FLAG --file $MAKIM_FILE --help
           makim $VERBOSE_FLAG --file $MAKIM_FILE --version
           makim $VERBOSE_FLAG --file $MAKIM_FILE group-no-path.target-no-path
@@ -300,7 +300,7 @@ groups:
           MAKIM_FILE: tests/smoke/.makim-working-directory-no-path.yaml
         shell: bash
         run: |
-          export VERBOSE_FLAG='{{ "--verbose" if args.verbose_mode else "" }}'
+          export VERBOSE_FLAG='${{ "--verbose" if args.verbose_mode else "" }}'
           export MAKIM_FILE="$(pwd)/${MAKIM_FILE}"
           cd /tmp
           makim $VERBOSE_FLAG --file $MAKIM_FILE --help
@@ -328,7 +328,7 @@ groups:
           MAKIM_FILE: tests/smoke/.makim-working-directory-relative-path.yaml
         shell: bash
         run: |
-          export VERBOSE_FLAG='{{ "--verbose" if args.verbose_mode else "" }}'
+          export VERBOSE_FLAG='${{ "--verbose" if args.verbose_mode else "" }}'
           export MAKIM_FILE="$(pwd)/${MAKIM_FILE}"
           mkdir -p /tmp/global-relative
           cd /tmp

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,53 +7,58 @@ repos:
     hooks:
       - id: end-of-file-fixer
 
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: "v3.1.0"
+    hooks:
+      - id: prettier
+
   - repo: local
     hooks:
-    - id: ruff-format
-      name: ruff-format
-      entry: ruff format
-      exclude: |
-        (?x)(
-          docs
-        )
-      language: system
-      pass_filenames: true
-      types:
-        - python
+      - id: ruff-format
+        name: ruff-format
+        entry: ruff format
+        exclude: |
+          (?x)(
+            docs
+          )
+        language: system
+        pass_filenames: true
+        types:
+          - python
 
-    - id: ruff-linter
-      name: ruff-linter
-      entry: ruff check
-      language: system
-      exclude: "docs/"
-      pass_filenames: true
-      types:
-        - python
+      - id: ruff-linter
+        name: ruff-linter
+        entry: ruff check
+        language: system
+        exclude: "docs/"
+        pass_filenames: true
+        types:
+          - python
 
-    - id: mypy
-      name: mypy
-      entry: mypy
-      language: system
-      files: "makim/"
-      pass_filenames: true
-      types:
-        - python
+      - id: mypy
+        name: mypy
+        entry: mypy
+        language: system
+        files: "makim/"
+        pass_filenames: true
+        types:
+          - python
 
-    - id: bandit
-      name: bandit
-      entry: bandit
-      language: system
-      args: ['--configfile', 'pyproject.toml']
-      pass_filenames: true
-      types:
-        - python
+      - id: bandit
+        name: bandit
+        entry: bandit
+        language: system
+        args: ["--configfile", "pyproject.toml"]
+        pass_filenames: true
+        types:
+          - python
 
-    - id: vulture
-      name: vulture
-      entry: vulture --min-confidence 80
-      language: system
-      files: "makim/"
-      description: Find unused Python code.
-      pass_filenames: true
-      types:
-        - python
+      - id: vulture
+        name: vulture
+        entry: vulture --min-confidence 80
+        language: system
+        files: "makim/"
+        description: Find unused Python code.
+        pass_filenames: true
+        types:
+          - python

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,1 @@
-.makim.yaml
 docs/changelog.md

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,9 +3,11 @@
   "tagFormat": "${version}",
   "plugins": [
     [
-      "@semantic-release/commit-analyzer", {
+      "@semantic-release/commit-analyzer",
+      {
         "preset": "conventionalcommits"
-    }],
+      }
+    ],
     [
       "semantic-release-replace-plugin",
       {

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,8 +6,8 @@ We as members, contributors, and leaders pledge to make participation in our
 community a harassment-free experience for everyone, regardless of age, body
 size, visible or invisible disability, ethnicity, sex characteristics, gender
 identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, religion, or sexual identity
-and orientation.
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
 
 We pledge to act and interact in ways that contribute to an open, welcoming,
 diverse, inclusive, and healthy community.
@@ -17,23 +17,23 @@ diverse, inclusive, and healthy community.
 Examples of behavior that contributes to a positive environment for our
 community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
-  overall community
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or
-  advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
-  address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Enforcement Responsibilities
@@ -60,8 +60,8 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-opensciencelabs@gmail.com.
-All complaints will be reviewed and investigated promptly and fairly.
+opensciencelabs@gmail.com. All complaints will be reviewed and investigated
+promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.
@@ -82,15 +82,15 @@ behavior was inappropriate. A public apology may be requested.
 
 ### 2. Warning
 
-**Community Impact**: A violation through a single incident or series
-of actions.
+**Community Impact**: A violation through a single incident or series of
+actions.
 
 **Consequence**: A warning with consequences for continued behavior. No
 interaction with the people involved, including unsolicited interaction with
 those enforcing the Code of Conduct, for a specified period of time. This
 includes avoiding interactions in community spaces as well as external channels
-like social media. Violating these terms may lead to a temporary or
-permanent ban.
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
 
 ### 3. Temporary Ban
 
@@ -106,11 +106,11 @@ Violating these terms may lead to a permanent ban.
 ### 4. Permanent Ban
 
 **Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
+standards, including sustained inappropriate behavior, harassment of an
 individual, or aggression toward or disparagement of classes of individuals.
 
-**Consequence**: A permanent ban from any sort of public interaction within
-the community.
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
 
 ## Attribution
 
@@ -118,8 +118,8 @@ This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.0, available at
 https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
 
-Community Impact Guidelines were inspired by [Mozilla's code of conduct
-enforcement ladder](https://github.com/mozilla/diversity).
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
 
 [homepage]: https://www.contributor-covenant.org
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ groups:
             help: if not set, the clean dependency will not be triggered.
         dependencies:
           - target: clean
-            if: {% raw %}{{ args.clean == true }}{% endraw %}
+            if: {% raw %}${{ args.clean == true }}{% endraw %}
         run: |
           echo "build file x"
           echo "build file y"

--- a/conda/dev.yaml
+++ b/conda/dev.yaml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - bash
-  - python 3.8.1  # min version supported
+  - python 3.8.1 # min version supported
   - poetry >=1.5
   - nodejs
   - perl
@@ -12,8 +12,8 @@ dependencies:
   - sh
   - pip
   - pip:
-    # note: workaround ci issue for macos
-    - setuptools >= 40.8.0
-    - wheel >=0.42.0
-    # fix the distlib issue
-    - paginate >=0.5
+      # note: workaround ci issue for macos
+      - setuptools >= 40.8.0
+      - wheel >=0.42.0
+      # fix the distlib issue
+      - paginate >=0.5

--- a/conda/release.yaml
+++ b/conda/release.yaml
@@ -3,10 +3,10 @@ channels:
   - nodefaults
   - conda-forge
 dependencies:
-  - python >=3.8.1,<3.12  # min version supported
+  - python >=3.8.1,<3.12 # min version supported
   - poetry >=1.5
-  - nodejs >=18.17  # used by semantic-release
+  - nodejs >=18.17 # used by semantic-release
   - pip
   - pip:
-    # fix the distlib issue
-    - paginate >=0.5
+      # fix the distlib issue
+      - paginate >=0.5

--- a/docs/features.md
+++ b/docs/features.md
@@ -2,63 +2,63 @@
 
 ## Attribute: working-directory
 
-The working-directory feature in Makim allows users to define the directory
-from which commands associated with specific targets or groups are executed.
-This provides greater flexibility and control over the execution environment.
+The working-directory feature in Makim allows users to define the directory from
+which commands associated with specific targets or groups are executed. This
+provides greater flexibility and control over the execution environment.
 
-The `working-directory` attribute can be specified at three different
-scopes: global, group, and target. It allows users to set the working
-directory for a specific target, a group of targets, or globally.
+The `working-directory` attribute can be specified at three different scopes:
+global, group, and target. It allows users to set the working directory for a
+specific target, a group of targets, or globally.
 
 ### Syntax and Scopes
+
 The working-directory attribute can be applied to three different scopes:
 
 - #### **Global Scope**
-    Setting the global working directory impacts all targets and groups in
-    the Makim configuration.
 
-    ```yaml
-    version: 1.0
-    working-directory: /path/to/global/directory
+  Setting the global working directory impacts all targets and groups in the
+  Makim configuration.
 
-    # ... other configuration ...
-    ```
+  ```yaml
+  version: 1.0
+  working-directory: /path/to/global/directory
+  # ... other configuration ...
+  ```
 
 - #### Group Scope
 
-    Setting the working directory at the group scope affects all targets within
-    that group.
+  Setting the working directory at the group scope affects all targets within
+  that group.
 
-    ```yaml
+  ```yaml
+  version: 1.0
 
-    version: 1.0
-
-    groups:
-        my-group:
-            working-directory: /path/to/group/directory
-            targets:
-                target-1:
-                    run: |
-                    # This target will run with the working directory set to
-                    # /path/to/group/directory
-    ```
+  groups:
+    my-group:
+      working-directory: /path/to/group/directory
+      targets:
+        target-1:
+          run: |
+          # This target will run with the working directory set to
+          # /path/to/group/directory
+  ```
 
 - #### Target Scope
 
-    Setting the working directory at the target scope allows for fine grained
-    control over individual targets.
+  Setting the working directory at the target scope allows for fine grained
+  control over individual targets.
 
-    ```yaml
-    version: 1.0
-    groups:
-        my-group:
-            targets:
-                my-target:
-                    working-directory: /path/to/target/directory
-                    run: |
-                    # This target will run with the working directory set to
-                    # /path/to/target/directory
-    ```
+  ```yaml
+  version: 1.0
+  groups:
+    my-group:
+      targets:
+        my-target:
+          working-directory: /path/to/target/directory
+          run: |
+          # This target will run with the working directory set to
+          # /path/to/target/directory
+  ```
 
 ## Example
 
@@ -83,5 +83,4 @@ groups:
         run: |
           echo "Running backend tests..."
           # Additional test commands specific to the backend
-
 ```

--- a/docs/images/site.webmanifest
+++ b/docs/images/site.webmanifest
@@ -1,1 +1,19 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{
+  "name": "",
+  "short_name": "",
+  "icons": [
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff",
+  "display": "standalone"
+}

--- a/docs/template.md
+++ b/docs/template.md
@@ -1,7 +1,7 @@
 # Makim Template
 
-**Makim** config files are powered by the Jinja2 template engine, allowing
-you to use Jinja2 tags for added flexibility in your Makim config files.
+**Makim** config files are powered by the Jinja2 template engine, allowing you
+to use Jinja2 tags for added flexibility in your Makim config files.
 
 This page focuses on explaining the options offered directly by **Makim**,
 rather than covering all the possibilities with Jinja2.
@@ -10,57 +10,56 @@ rather than covering all the possibilities with Jinja2.
 `vars`, `env`, and `args`.
 
 Additionally, the `env` and `vars` option has three different scopes:
-**global**, **group**, and **target**.
-We will discuss each of them in the following sections.
+**global**, **group**, and **target**. We will discuss each of them in the
+following sections.
 
 ## Variables Scopes
 
-Before delving into the different variable options, let's discuss `env`
-and `vars` scope, as it is essential for the subsequent sections.
-The `args` attribute just works in the *target* scope.
+Before delving into the different variable options, let's discuss `env` and
+`vars` scope, as it is essential for the subsequent sections. The `args`
+attribute just works in the _target_ scope.
 
-As mentioned earlier, **Makim** `env` and `vars` has three scopes:
-**global**, **group**, and **target**.
+As mentioned earlier, **Makim** `env` and `vars` has three scopes: **global**,
+**group**, and **target**.
 
-The order of their rendering is crucial. First, the *global* scope is processed.
-In the *group* scope, any variable defined globally is accessible via the `env`
-variable (e.g., `{% raw %}{{ env.my_global_env }}{% endraw %}`).
-However, any variable defined in the *global* scope will be overridden by a
-variable with the same name in the *group* scope. The same applies to the
-*target* scope, where any variable defined in the *global* or *group* scope
-will be overridden by a variable defined in the *target* scope.
+The order of their rendering is crucial. First, the _global_ scope is processed.
+In the _group_ scope, any variable defined globally is accessible via the `env`
+variable (e.g., `{% raw %}${{ env.my_global_env }}{% endraw %}`). However, any
+variable defined in the _global_ scope will be overridden by a variable with the
+same name in the _group_ scope. The same applies to the _target_ scope, where
+any variable defined in the _global_ or _group_ scope will be overridden by a
+variable defined in the _target_ scope.
 
 Moreover, `env` is a bit more complex, as its value can be defined in two
-different ways: either through the `env` attribute in the `.makim.yaml`
-file or from an environment file specified in the `env-file` attribute.
-First, the `env-file` is loaded into memory, and then the variables
-defined in the `env` attribute are loaded. In other words, any variable
-defined in the file for the given `env-file` will be overridden by a
-variable of the same name defined in the `env` attribute. This process
-also respects the order of scopes.
+different ways: either through the `env` attribute in the `.makim.yaml` file or
+from an environment file specified in the `env-file` attribute. First, the
+`env-file` is loaded into memory, and then the variables defined in the `env`
+attribute are loaded. In other words, any variable defined in the file for the
+given `env-file` will be overridden by a variable of the same name defined in
+the `env` attribute. This process also respects the order of scopes.
 
-PS: **Makim** utilizes system environment variables as the initial scope for
-the variables.
+PS: **Makim** utilizes system environment variables as the initial scope for the
+variables.
 
 ## Different Variable Options
 
-**Makim** offers three variable options within the `makim` config file:
-`env`, `vars`, and `args`.
+**Makim** offers three variable options within the `makim` config file: `env`,
+`vars`, and `args`.
 
-* `args` allows users to pass parameters via the CLI (command line interface).
-It can also be used for target dependencies when parameters need to be passed
-to the dependency. However, this option is not available in the system context
-(the commands executed defined by `run` attribute), it is only accessible
-within the Makim config file.
-* `vars` is a convenient way to define reusable variables in the code. For
-example, if you frequently use a command in the `run` section, you can define
-a variable inside `vars` to make the Makim file more readable. Like `args`,
-this option is not available in the system context; it is only accessible
-within the Makim config file.
-* `env` is used to define environment variables. Any environment variable can
-be accessed via the `env` variable in the template (e.g.,
-`{% raw %}{{ env.myenvvar }}{% endraw %}`) or directly as an environment
-variable within the `run` section, as shown in the example below:
+- `args` allows users to pass parameters via the CLI (command line interface).
+  It can also be used for target dependencies when parameters need to be passed
+  to the dependency. However, this option is not available in the system context
+  (the commands executed defined by `run` attribute), it is only accessible
+  within the Makim config file.
+- `vars` is a convenient way to define reusable variables in the code. For
+  example, if you frequently use a command in the `run` section, you can define
+  a variable inside `vars` to make the Makim file more readable. Like `args`,
+  this option is not available in the system context; it is only accessible
+  within the Makim config file.
+- `env` is used to define environment variables. Any environment variable can be
+  accessed via the `env` variable in the template (e.g.,
+  `{% raw %}${{ env.myenvvar }}{% endraw %}`) or directly as an environment
+  variable within the `run` section, as shown in the example below:
 
 ```yaml
 ...
@@ -77,28 +76,29 @@ groups:
 
 ## Order of Variable Rendering
 
-One crucial point to keep in mind is the order of variable rendering
-within the Makim config file.
+One crucial point to keep in mind is the order of variable rendering within the
+Makim config file.
 
-`vars` is primarily used for `run` section,  so they have the lowest
-precedence. In another word, you can use `env` or `arg` to create
-`vars`, but not the opposite way.
+`vars` is primarily used for `run` section, so they have the lowest precedence.
+In another word, you can use `env` or `arg` to create `vars`, but not the
+opposite way.
 
-`env` however, can be defined also in the system scope, so it has the
-highest rank in the precedence. So, you shouldn't define a `env` that
-depends on a variable defined by `vars` or `args`. If you need to set
-your environment variable with a value from a `vars` or `args`, you
-should do it in the `run` section.
+`env` however, can be defined also in the system scope, so it has the highest
+rank in the precedence. So, you shouldn't define a `env` that depends on a
+variable defined by `vars` or `args`. If you need to set your environment
+variable with a value from a `vars` or `args`, you should do it in the `run`
+section.
 
-In the following example, it shows a correct way to use all the
-different options of variables, respecting the scopes and rendering order:
+In the following example, it shows a correct way to use all the different
+options of variables, respecting the scopes and rendering order:
 
 ```yaml
-...
+---
 env:
   MY_GLOBAL_ENV: 1
 vars:
-  MY_GLOBAL_VAR: "my global env is {% raw %}{{ env.MY_GLOBAL_ENV }}{% endraw %}"
+  MY_GLOBAL_VAR:
+    "my global env is {% raw %}${{ env.MY_GLOBAL_ENV }}{% endraw %}"
 
 groups:
   group1:
@@ -106,7 +106,8 @@ groups:
     env:
       MY_GROUP_ENV: 2
     vars:
-      MY_GROUP_VAR: "my group env is {% raw %}{{ env.MY_GROUP_ENV }}{% endraw %}"
+      MY_GROUP_VAR:
+        "my group env is {% raw %}${{ env.MY_GROUP_ENV }}{% endraw %}"
     targets:
       target1:
         help: "target 1"
@@ -116,15 +117,16 @@ groups:
           my-target-arg:
             help: "target arg"
             type: string
-            default: "{% raw %}{{ env.MY_TARGET_ENV }}{% endraw %}"
+            default: "{% raw %}${{ env.MY_TARGET_ENV }}{% endraw %}"
         vars:
-          MY_TARGET_VAR: "my group env is {% raw %}{{ env.MY_GROUP_ENV }}{% endraw %}"
+          MY_TARGET_VAR:
+            "my group env is {% raw %}${{ env.MY_GROUP_ENV }}{% endraw %}"
         run: |
-          echo "{% raw %}{{ env.MY_GLOBAL_ENV}}{% endraw %}"
-          echo "{% raw %}{{ env.MY_GLOBAL_VAR}}{% endraw %}"
-          echo "{% raw %}{{ env.MY_GROUP_ENV}}{% endraw %}"
-          echo "{% raw %}{{ env.MY_GROUP_VAR}}{% endraw %}"
-          echo "{% raw %}{{ env.MY_TARGET_ENV}}{% endraw %}"
-          echo "{% raw %}{{ env.MY_TARGET_VAR}}{% endraw %}"
-          echo "{% raw %}{{ env.my_target_arg}}{% endraw %}"
+          echo "{% raw %}${{ env.MY_GLOBAL_ENV}}{% endraw %}"
+          echo "{% raw %}${{ env.MY_GLOBAL_VAR}}{% endraw %}"
+          echo "{% raw %}${{ env.MY_GROUP_ENV}}{% endraw %}"
+          echo "{% raw %}${{ env.MY_GROUP_VAR}}{% endraw %}"
+          echo "{% raw %}${{ env.MY_TARGET_ENV}}{% endraw %}"
+          echo "{% raw %}${{ env.MY_TARGET_VAR}}{% endraw %}"
+          echo "{% raw %}${{ env.my_target_arg}}{% endraw %}"
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ quote-style = "single"
 [tool.bandit]
 exclude_dirs = ["tests"]
 targets = "src/makim/"
-skips = ["B102"]
+skips = ["B102", "B701"]
 
 [tool.vulture]
 exclude = ["tests"]

--- a/src/makim/core.py
+++ b/src/makim/core.py
@@ -45,16 +45,6 @@ TEMPLATE = Environment(
 )
 
 
-def escape_template_tag(v: str) -> str:
-    """Escape template tag when processing the template config file."""
-    return v.replace('${{', r'\{\{').replace('}}', r'\}\}')
-
-
-def unescape_template_tag(v: str) -> str:
-    """Unescape template tag when processing the template config file."""
-    return v.replace(r'\{\{', '${{').replace(r'\}\}', '}}')
-
-
 def strip_recursively(data: Any) -> Any:
     """Strip strings in list and dictionaries."""
     if isinstance(data, str):
@@ -242,7 +232,7 @@ class Makim:
 
         with open(self.file, 'r') as f:
             # escape template tags
-            content = escape_template_tag(f.read())
+            content = f.read()
             content_io = io.StringIO(content)
             self.global_data = yaml.safe_load(content_io)
 
@@ -322,9 +312,9 @@ class Makim:
         ):
             env.update(env_file)
             for k, v in env_user.items():
-                env[k] = TEMPLATE.from_string(
-                    unescape_template_tag(str(v))
-                ).render(env=env, vars=variables)
+                env[k] = TEMPLATE.from_string(str(v)).render(
+                    env=env, vars=variables
+                )
 
         scope_id = scope_options.index(scope)
 
@@ -430,7 +420,7 @@ class Makim:
             # update the arguments
             for arg_name, arg_value in dep_data.get('args', {}).items():
                 unescaped_value = (
-                    unescape_template_tag(str(arg_value))
+                    str(arg_value)
                     if isinstance(arg_value, str)
                     else str(arg_value)
                 )
@@ -447,9 +437,9 @@ class Makim:
             # checking for the conditional statement
             if_stmt = dep_data.get('if')
             if if_stmt:
-                result = TEMPLATE.from_string(
-                    unescape_template_tag(str(if_stmt))
-                ).render(args=original_args_clean, env=self.env_scoped)
+                result = TEMPLATE.from_string(str(if_stmt)).render(
+                    args=original_args_clean, env=self.env_scoped
+                )
                 if not yaml.safe_load(result):
                     if self.verbose:
                         MakimLogs.print_info(
@@ -509,7 +499,7 @@ class Makim:
                     MakimError.MAKIM_ARGUMENT_REQUIRED,
                 )
 
-        cmd = unescape_template_tag(str(cmd))
+        cmd = str(cmd)
         cmd = TEMPLATE.from_string(cmd).render(
             args=args_input, env=env, vars=variables
         )

--- a/src/makim/core.py
+++ b/src/makim/core.py
@@ -39,7 +39,7 @@ KNOWN_SHELL_APP_ARGS = {
 }
 
 TEMPLATE = Environment(
-    autoescape=True,
+    autoescape=False,
     variable_start_string='${{',
     variable_end_string='}}',
 )

--- a/tests/smoke/.makim-complex.yaml
+++ b/tests/smoke/.makim-complex.yaml
@@ -31,7 +31,7 @@ groups:
               Define a custom value for the environment variable
               `ASAN_OPTIONS`
             type: string
-            default: ''
+            default: ""
           build-type:
             help: |
               Define the build type, options are:
@@ -45,15 +45,15 @@ groups:
           extras:
             help: Extra arguments for the build step
             type: string
-            default: ''
+            default: ""
         dependencies:
           - target: build.clean
-            if: {{ args.clean }}
+            if: ${{ args.clean }}
         run: |
-          $ASAN_OPTIONS = '{{ args.asan_options }}'
+          $ASAN_OPTIONS = '${{ args.asan_options }}'
           echo "[II] Build the package for release options:"
-          echo "\tbuild-type: {{ args.build_type }}"
-          echo "\textras: {{ args.extras }}"
+          echo "\tbuild-type: ${{ args.build_type }}"
+          echo "\textras: ${{ args.extras }}"
 
       dev:
         help: Build for development (+tests +debug)
@@ -67,7 +67,7 @@ groups:
             args:
               build-type: "debug"
               extra: "-Ddev=enabled -Db_coverage=true -Doptimization=0"
-              clean: {{ args.clean }}
+              clean: ${{ args.clean }}
               asan-options: "fast_unwind_on_malloc=0"
 
   env:
@@ -88,11 +88,11 @@ groups:
     targets:
       ci:
         help: Run semantic-release on CI
-        run: {{ vars.app }} --ci
+        run: ${{ vars.app }} --ci
 
       dry:
         help: Run semantic-release on CI for tests in dry-run mode.
-        run: {{ vars.app }} --dry-run
+        run: ${{ vars.app }} --dry-run
 
   docs:
     targets:
@@ -173,7 +173,7 @@ groups:
 
       dotenv-var:
         help: Print environment variables from .env file
-        run:  echo "[II] $ENV"
+        run: echo "[II] $ENV"
 
       required-arg:
         help: Print a required argument `name`
@@ -182,7 +182,7 @@ groups:
             help: A name to be printed
             type: string
             required: true
-        run:  echo "[II] {{ args.name }}"
+        run: echo "[II] ${{ args.name }}"
 
       nested:
         help: Print using nested commands

--- a/tests/smoke/.makim-env.yaml
+++ b/tests/smoke/.makim-env.yaml
@@ -73,8 +73,7 @@ groups:
             help: my_value
             type: string
         run: |
-          assert "{{ args.my_value }}" == "{{ env.GROUP_VAR_1 }}" == "1"
-
+          assert "${{ args.my_value }}" == "${{ env.GROUP_VAR_1 }}" == "1"
 
       from-global:
         help: Test a rerender from the global scope
@@ -82,11 +81,11 @@ groups:
         dependencies:
           - target: rerender-env.dep
             args:
-              my-value: '{{ env.GROUP_VAR_1 }}'
+              my-value: "${{ env.GROUP_VAR_1 }}"
         env:
-          MYVAR_1: {{ env.GLOBAL_VAR_1 }}
-          MYVAR_2: {{ env.GLOBAL_VAR_2 }}
-          MYVAR_3: {{ env.ENV }}
+          MYVAR_1: ${{ env.GLOBAL_VAR_1 }}
+          MYVAR_2: ${{ env.GLOBAL_VAR_2 }}
+          MYVAR_3: ${{ env.ENV }}
         run: |
           import os
           assert str(os.getenv("MYVAR_1")) == "1"
@@ -97,9 +96,9 @@ groups:
         help: Test a rerender from the group scope
         env-file: .env-group
         env:
-          MYVAR_1: {{ env.GROUP_VAR_1 }}
-          MYVAR_2: {{ env.GROUP_VAR_2 }}
-          MYVAR_3: {{ env.ENV }}
+          MYVAR_1: ${{ env.GROUP_VAR_1 }}
+          MYVAR_2: ${{ env.GROUP_VAR_2 }}
+          MYVAR_3: ${{ env.ENV }}
         run: |
           import os
           assert str(os.getenv("MYVAR_1")) == "1"
@@ -110,7 +109,7 @@ groups:
         help: Test a rerender from the group scope
         env-file: .env-target
         env:
-          MYVAR_1: {{ env.ENV }}
+          MYVAR_1: ${{ env.ENV }}
         run: |
           import os
           assert str(os.getenv("MYVAR_1")) == "test"

--- a/tests/smoke/.makim-simple.yaml
+++ b/tests/smoke/.makim-simple.yaml
@@ -11,7 +11,7 @@ groups:
             action: store_true
             help: Remove all files that are tracked by git
         run: |
-          if {{ args.all }} == True:
+          if ${{ args.all }} == True:
             echo "[II] Remove all files"
           else:
             echo "remove file X"
@@ -33,9 +33,9 @@ groups:
             action: store_true
         dependencies:
           - target: default.clean
-            if: {{ args.clean or args.clean_all }}
+            if: ${{ args.clean or args.clean_all }}
             args:
-              all: {{ args.clean_all }}
+              all: ${{ args.clean_all }}
         run: |
           echo "build file x"
           echo "build file y"

--- a/tests/smoke/.makim-unittest.yaml
+++ b/tests/smoke/.makim-unittest.yaml
@@ -10,7 +10,7 @@ groups:
             type: bool
             action: store_true
             help: arg `all`
-        run: assert not {{ args.all }}
+        run: assert not ${{ args.all }}
 
       test-2:
         help: test-2 args `all` should be true
@@ -19,7 +19,7 @@ groups:
             type: bool
             action: store_true
             help: arg `all`
-        run: assert {{ args.all }}
+        run: assert ${{ args.all }}
 
       test-3-a:
         help: test-3-a is a dep for test-3-b
@@ -38,7 +38,7 @@ groups:
             help: arg1
             type: bool
             action: store_true
-        run: assert {{ args.arg1 }}
+        run: assert ${{ args.arg1 }}
 
       test-4:
         help: test-4
@@ -49,9 +49,9 @@ groups:
             action: store_true
         dependencies:
           - target: test-4-dep
-            if: {{ args.trigger_dep }}
+            if: ${{ args.trigger_dep }}
             args:
-              arg1: {{ args.trigger_dep }}
+              arg1: ${{ args.trigger_dep }}
         run: "true"
 
       test-5-dep:
@@ -67,7 +67,7 @@ groups:
             action: store_true
         dependencies:
           - target: test-5-dep
-            if: {{ args.trigger_dep }}
+            if: ${{ args.trigger_dep }}
         run: assert True
 
       test-6-dep-1:
@@ -91,32 +91,32 @@ groups:
             action: store_true
         dependencies:
           - target: test-6-dep-1
-            if: {{ True }}
+            if: ${{ True }}
           - target: test-6-dep-2
-            if: {{ False }}
+            if: ${{ False }}
           - target: test-6-dep-3
-            if: {{ True }}
+            if: ${{ True }}
         run: |
           cat /tmp/makim-test.txt | grep "OK"
           rm -f /tmp/makim-test.txt
 
       test-7:
-          help: test required arg
-          args:
-            arg_required:
-              help: a required argument
-              required: true
-              type: string
-          run: echo "OK" > /tmp/makim-test.txt
+        help: test required arg
+        args:
+          arg_required:
+            help: a required argument
+            required: true
+            type: string
+        run: echo "OK" > /tmp/makim-test.txt
 
       test-8:
-          help: failure test in 1 line
-          shell: bash
-          run: "false"
+        help: failure test in 1 line
+        shell: bash
+        run: "false"
 
       test-9:
-          help: failure test in the first line of 2 lines
-          shell: bash
-          run: |
-            false
-            true
+        help: failure test in the first line of 2 lines
+        shell: bash
+        run: |
+          false
+          true

--- a/tests/smoke/.makim-vars.yaml
+++ b/tests/smoke/.makim-vars.yaml
@@ -17,8 +17,8 @@ vars:
     kglobal2:
       kglobal2-nested:
         - kglobal2-nested-2:
-          - 1
-          - 2
+            - 1
+            - 2
 groups:
   vars-group:
     vars:
@@ -46,32 +46,32 @@ groups:
             - vtarget3
         run: |
           # global
-          assert "{{ vars.get("global-var-str") }}" == "global"
-          assert "{{ vars.global_var_str }}" == "global"
-          assert "{{ vars.global_var_dict["kglobal1"] }}" == "vglobal1"
-          assert "{{ vars.global_var_dict["kglobal2"] }}" == "vglobal2"
-          assert "{{ vars.global_var_dict["kglobal3"] }}" == "vglobal3"
-          assert "{{ vars.global_var_list[0] }}" == "vglobal1"
-          assert "{{ vars.global_var_list[1] }}" == "vglobal2"
-          assert "{{ vars.global_var_list[2] }}" == "vglobal3"
-          assert "{{ vars.global_var_complex_type["kglobal1"][0] }}" == "vglobal1"
+          assert "${{ vars.get("global-var-str") }}" == "global"
+          assert "${{ vars.global_var_str }}" == "global"
+          assert "${{ vars.global_var_dict["kglobal1"] }}" == "vglobal1"
+          assert "${{ vars.global_var_dict["kglobal2"] }}" == "vglobal2"
+          assert "${{ vars.global_var_dict["kglobal3"] }}" == "vglobal3"
+          assert "${{ vars.global_var_list[0] }}" == "vglobal1"
+          assert "${{ vars.global_var_list[1] }}" == "vglobal2"
+          assert "${{ vars.global_var_list[2] }}" == "vglobal3"
+          assert "${{ vars.global_var_complex_type["kglobal1"][0] }}" == "vglobal1"
 
           # group
-          assert "{{ vars.get("group-var-str") }}" == "group"
-          assert "{{ vars.group_var_str }}" == "group"
-          assert "{{ vars.group_var_dict["kgroup1"] }}" == "vgroup1"
-          assert "{{ vars.group_var_dict["kgroup2"] }}" == "vgroup2"
-          assert "{{ vars.group_var_dict["kgroup3"] }}" == "vgroup3"
-          assert "{{ vars.group_var_list[0] }}" == "vgroup1"
-          assert "{{ vars.group_var_list[1] }}" == "vgroup2"
-          assert "{{ vars.group_var_list[2] }}" == "vgroup3"
+          assert "${{ vars.get("group-var-str") }}" == "group"
+          assert "${{ vars.group_var_str }}" == "group"
+          assert "${{ vars.group_var_dict["kgroup1"] }}" == "vgroup1"
+          assert "${{ vars.group_var_dict["kgroup2"] }}" == "vgroup2"
+          assert "${{ vars.group_var_dict["kgroup3"] }}" == "vgroup3"
+          assert "${{ vars.group_var_list[0] }}" == "vgroup1"
+          assert "${{ vars.group_var_list[1] }}" == "vgroup2"
+          assert "${{ vars.group_var_list[2] }}" == "vgroup3"
 
           # target
-          assert "{{ vars.get("target-var-str") }}" == "target"
-          assert "{{ vars.target_var_str }}" == "target"
-          assert "{{ vars.target_var_dict["ktarget1"] }}" == "vtarget1"
-          assert "{{ vars.target_var_dict["ktarget2"] }}" == "vtarget2"
-          assert "{{ vars.target_var_dict["ktarget3"] }}" == "vtarget3"
-          assert "{{ vars.target_var_list[0] }}" == "vtarget1"
-          assert "{{ vars.target_var_list[1] }}" == "vtarget2"
-          assert "{{ vars.target_var_list[2] }}" == "vtarget3"
+          assert "${{ vars.get("target-var-str") }}" == "target"
+          assert "${{ vars.target_var_str }}" == "target"
+          assert "${{ vars.target_var_dict["ktarget1"] }}" == "vtarget1"
+          assert "${{ vars.target_var_dict["ktarget2"] }}" == "vtarget2"
+          assert "${{ vars.target_var_dict["ktarget3"] }}" == "vtarget3"
+          assert "${{ vars.target_var_list[0] }}" == "vtarget1"
+          assert "${{ vars.target_var_list[1] }}" == "vtarget2"
+          assert "${{ vars.target_var_list[2] }}" == "vtarget3"

--- a/tests/smoke/.makim-working-directory-absolute-path.yaml
+++ b/tests/smoke/.makim-working-directory-absolute-path.yaml
@@ -17,7 +17,7 @@ groups:
     targets:
       target-no-path:
         help: Test global absolute path, group no path, target no path
-        dependencies: 
+        dependencies:
           - target: setup.folders
         run: |
           import os
@@ -28,7 +28,7 @@ groups:
       target-absolute:
         working-directory: "/tmp"
         help: Test global absolute path, group no path, target absolute path
-        dependencies: 
+        dependencies:
           - target: setup.folders
         run: |
           import os
@@ -38,19 +38,19 @@ groups:
       target-relative:
         working-directory: "/tmp/group1/target4"
         help: est global absolute path, group no path, target relative path
-        dependencies: 
+        dependencies:
           - target: setup.folders
         run: |
           import os
           assert os.getcwd() == "/tmp/group1/target4"
           echo "working-directory-absolute-path [III] Done!"
-          
+
   group-relative:
     working-directory: "group1"
     targets:
       target-no-path:
         help: Test global absolute path, group relative path, target no path
-        dependencies: 
+        dependencies:
           - target: setup.folders
         run: |
           import os
@@ -60,7 +60,7 @@ groups:
       target-absolute:
         working-directory: "/tmp"
         help: Test global absolute path, group relative path, target absolute path
-        dependencies: 
+        dependencies:
           - target: setup.folders
         run: |
           import os
@@ -70,7 +70,7 @@ groups:
       target-relative:
         working-directory: "target3"
         help: Test global absolute path, group relative path, target relative path
-        dependencies: 
+        dependencies:
           - target: setup.folders
         run: |
           import os
@@ -82,7 +82,7 @@ groups:
     targets:
       target-no-path:
         help: Test global absolute path, group absolute path, target no path
-        dependencies: 
+        dependencies:
           - target: setup.folders
         run: |
           import os 
@@ -92,7 +92,7 @@ groups:
       target-absolute:
         working-directory: "/tmp"
         help: Test global absolute path, group absolute path, target absolute path
-        dependencies: 
+        dependencies:
           - target: setup.folders
         run: |
           import os
@@ -103,7 +103,7 @@ groups:
         working-directory: "target-relative"
         help: |
           Test global absolute path, group absolute path, target relative  path
-        dependencies: 
+        dependencies:
           - target: setup.folders
         run: |
           import os

--- a/tests/smoke/.makim-working-directory-no-path.yaml
+++ b/tests/smoke/.makim-working-directory-no-path.yaml
@@ -3,7 +3,7 @@ version: 1.0
 groups:
   setup:
     targets:
-       create-folders:
+      create-folders:
         run: |
           mkdir -p /tmp/target1
           mkdir -p /tmp/target2
@@ -11,20 +11,20 @@ groups:
           mkdir -p /tmp/group-relative/target1
 
   group-no-path:
-    targets: 
+    targets:
       target-no-path:
         help: Test global no-path, group no-path, target no-path
-        dependencies: 
+        dependencies:
           - target: setup.create-folders
         run: |
           import os
           echo f"{os.getcwd()}"
           echo "working-directory-no-path [I] Done!"
-      
+
       target-absolute:
         working-directory: "/tmp/target1"
         help: Test global no-path, group no-path, target absolute
-        dependencies: 
+        dependencies:
           - target: setup.create-folders
         run: |
           import os
@@ -34,7 +34,7 @@ groups:
       target-relative:
         working-directory: "target2"
         help: Test global no-path, group no-path, target relative
-        dependencies: 
+        dependencies:
           - target: setup.create-folders
         run: |
           import os
@@ -46,8 +46,8 @@ groups:
     targets:
       target-no-path:
         help: Test global no-path, group absolute path, target no-path
-        dependencies: 
-        - target: setup.create-folders
+        dependencies:
+          - target: setup.create-folders
         run: |
           import os
           assert os.getcwd() == "/tmp/group-absolute"
@@ -56,18 +56,18 @@ groups:
       target-absolute:
         working-directory: /tmp/target1
         help: Test global no-path, group absolute path, target absolute path
-        dependencies: 
-        - target: setup.create-folders
+        dependencies:
+          - target: setup.create-folders
         run: |
-            import os
-            assert os.getcwd() == "/tmp/target1"
-            echo "working-directory-no-path [V] Done!"
+          import os
+          assert os.getcwd() == "/tmp/target1"
+          echo "working-directory-no-path [V] Done!"
 
       target-relative:
         working-directory: "target1"
         help: Test global no-path, group absolute path, target relative path
-        dependencies: 
-        - target: setup.create-folders
+        dependencies:
+          - target: setup.create-folders
         run: |
           import os
           assert os.getcwd() == "/tmp/group-absolute/target1"
@@ -75,11 +75,11 @@ groups:
 
   group-relative:
     working-directory: "group-relative"
-    targets: 
+    targets:
       target-no-path:
         help: Test global no-path, group relative path, target no-path
-        dependencies: 
-        - target: setup.create-folders
+        dependencies:
+          - target: setup.create-folders
         run: |
           import os
           assert os.getcwd() == "/tmp/group-relative"
@@ -88,18 +88,18 @@ groups:
       target-absolute:
         working-directory: "/tmp/target2"
         help: Test global no-path, group relative path, target absolute path
-        dependencies: 
-        - target: setup.create-folders
+        dependencies:
+          - target: setup.create-folders
         run: |
           import os
           assert os.getcwd() == "/tmp/target2"
           echo "working-directory-no-path [VIII] Done!"
-          
+
       target-relative:
         working-directory: "target1"
         help: Test global no-path, group relative path, target relative path
-        dependencies: 
-        - target: setup.create-folders
+        dependencies:
+          - target: setup.create-folders
         run: |
           import os
           assert os.getcwd() == "/tmp/group-relative/target1"

--- a/tests/smoke/.makim-working-directory-relative-path.yaml
+++ b/tests/smoke/.makim-working-directory-relative-path.yaml
@@ -4,7 +4,7 @@ working-directory: "global-relative"
 groups:
   setup:
     targets:
-       create-folders:
+      create-folders:
         run: |
           mkdir -p /tmp/global-relative
           mkdir -p /tmp/global-relative/target1

--- a/tests/smoke/containers/compose.yaml
+++ b/tests/smoke/containers/compose.yaml
@@ -1,4 +1,4 @@
-version: '3.4'
+version: "3.4"
 
 services:
   service1:

--- a/tests/test_failure.py
+++ b/tests/test_failure.py
@@ -13,7 +13,7 @@ from makim.logs import MakimError
 @pytest.mark.parametrize(
     'target,args,error_code',
     [
-        ('tests.test-7', {}, MakimError.MAKIM_ARGUMENT_REQUIRED),
+        ('tests.test-7', {}, 1),
         ('tests.test-8', {}, MakimError.SH_ERROR_RETURN_CODE.value),
         ('tests.test-9', {}, MakimError.SH_ERROR_RETURN_CODE.value),
     ],

--- a/tests/test_failure.py
+++ b/tests/test_failure.py
@@ -13,7 +13,7 @@ from makim.logs import MakimError
 @pytest.mark.parametrize(
     'target,args,error_code',
     [
-        ('tests.test-7', {}, 1),
+        ('tests.test-7', {}, MakimError.MAKIM_ARGUMENT_REQUIRED),
         ('tests.test-8', {}, MakimError.SH_ERROR_RETURN_CODE.value),
         ('tests.test-9', {}, MakimError.SH_ERROR_RETURN_CODE.value),
     ],


### PR DESCRIPTION
## Pull Request description
<!-- Describe the purpose of your PR and the changes you have made. -->


This PR implements a new way to use the jinja2 tag delimiter, and instead of `{{ any_code }}` it will be `${{ any_code }}`.
it looks similar to github actions workflow variables, and this also allow us to use prettier auto-format tool to format our makim config file without any weird conflict.

<!-- Which issue this PR aims to resolve or fix? E.g.:
Solving issue #004
-->

## How to test these changes

<!-- Example:

* run `$ abc -p 1234`
* open the web browser with url localhost:1234
* ...
-->

* ```...```

<!-- Modify the options to suit your project. -->
## Pull Request checklists

This PR is a:
- [ ] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:
- [ ] it includes tests.
- [ ] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:
- [ ] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more complexity.
- [ ] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->

<!-- Add any other extra information that would help to understand the changes proposed by this PR -->

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
