### PR TITLE
refactor: Rename working-directory to dir

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -67,9 +67,9 @@ jobs:
           brew install gnu-sed
           echo 'export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"' >> ~/.bashrc
           echo 'export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"' >> ~/.bash_profile
-          gsed -i s:/tmp:/private/tmp:g tests/smoke/.makim-working-directory-absolute-path.yaml
-          gsed -i s:/tmp:/private/tmp:g tests/smoke/.makim-working-directory-no-path.yaml
-          gsed -i s:/tmp:/private/tmp:g tests/smoke/.makim-working-directory-relative-path.yaml
+          gsed -i s:/tmp:/private/tmp:g tests/smoke/.makim-dir-absolute-path.yaml
+          gsed -i s:/tmp:/private/tmp:g tests/smoke/.makim-dir-no-path.yaml
+          gsed -i s:/tmp:/private/tmp:g tests/smoke/.makim-dir-relative-path.yaml
 
       - name: Prepare conda environment (windows)
         if: ${{ matrix.os == 'windows' }}
@@ -126,14 +126,14 @@ jobs:
       - name: Run smoke test for variables
         run: makim smoke-tests.test-vars
 
-      - name: Run smoke test for working-directory-absolute-path
-        run: makim smoke-tests.working-directory-absolute-path
+      - name: Run smoke test for dir-absolute-path
+        run: makim smoke-tests.dir-absolute-path
 
-      - name: Run smoke test for working-directory-no-path
-        run: makim smoke-tests.working-directory-no-path
+      - name: Run smoke test for dir-no-path
+        run: makim smoke-tests.dir-no-path
 
-      - name: Run smoke test for working-directory-relative-path
-        run: makim smoke-tests.working-directory-relative-path
+      - name: Run smoke test for dir-relative-path
+        run: makim smoke-tests.dir-relative-path
 
       - name: Run unit tests
         run: makim tests.unittest

--- a/.makim.yaml
+++ b/.makim.yaml
@@ -78,9 +78,9 @@ groups:
           - task: smoke-tests.vars-env
           - task: smoke-tests.test-vars
           - task: smoke-tests.bash
-          - task: smoke-tests.working-directory-absolute-path
-          - task: smoke-tests.working-directory-no-path
-          - task: smoke-tests.working-directory-relative-path
+          - task: smoke-tests.dir-absolute-path
+          - task: smoke-tests.dir-no-path
+          - task: smoke-tests.dir-relative-path
 
       ci:
         help: Run all tasks used on CI
@@ -171,8 +171,8 @@ groups:
 
       shell-app:
         help: |
-          Test makim with working-directory for global no-path and its various
-          combinations with group and task working-directory
+          Test makim with dir for global no-path and its various
+          combinations with group and task dir
         args:
           verbose-mode:
             help: Run the all the tests in verbose mode
@@ -261,17 +261,17 @@ groups:
           makim $VERBOSE_FLAG --file tests/smoke/.makim-bash-group-scope.yaml group-scope.test
           makim $VERBOSE_FLAG --file tests/smoke/.makim-bash-task-scope.yaml task-scope.test
 
-      working-directory-absolute-path:
+      dir-absolute-path:
         help: |
-          Test makim with working-directory absolute for global path and its various
-          combinations with group and task working-directory
+          Test makim with dir absolute for global path and its various
+          combinations with group and task dir
         args:
           verbose-mode:
             help: Run the all the tests in verbose mode
             type: bool
             action: store_true
         env:
-          MAKIM_FILE: tests/smoke/.makim-working-directory-absolute-path.yaml
+          MAKIM_FILE: tests/smoke/.makim-dir-absolute-path.yaml
         shell: bash
         run: |
           export VERBOSE_FLAG='${{ "--verbose" if args.verbose_mode else "" }}'
@@ -287,17 +287,17 @@ groups:
           makim $VERBOSE_FLAG --file $MAKIM_FILE group-absolute.task-absolute
           makim $VERBOSE_FLAG --file $MAKIM_FILE group-absolute.task-relative
 
-      working-directory-no-path:
+      dir-no-path:
         help: |
-          Test makim with working-directory for global no-path and its
-          various combinations with group and task working-directory
+          Test makim with dir for global no-path and its
+          various combinations with group and task dir
         args:
           verbose-mode:
             help: Run the all the tests in verbose mode
             type: bool
             action: store_true
         env:
-          MAKIM_FILE: tests/smoke/.makim-working-directory-no-path.yaml
+          MAKIM_FILE: tests/smoke/.makim-dir-no-path.yaml
         shell: bash
         run: |
           export VERBOSE_FLAG='${{ "--verbose" if args.verbose_mode else "" }}'
@@ -315,17 +315,17 @@ groups:
           makim $VERBOSE_FLAG --file $MAKIM_FILE group-relative.task-absolute
           makim $VERBOSE_FLAG --file $MAKIM_FILE group-relative.task-relative
 
-      working-directory-relative-path:
+      dir-relative-path:
         help: |
-          Test makim with working-directory for global no-path and its various
-          combinations with group and task working-directory
+          Test makim with dir for global no-path and its various
+          combinations with group and task dir
         args:
           verbose-mode:
             help: Run the all the tests in verbose mode
             type: bool
             action: store_true
         env:
-          MAKIM_FILE: tests/smoke/.makim-working-directory-relative-path.yaml
+          MAKIM_FILE: tests/smoke/.makim-dir-relative-path.yaml
         shell: bash
         run: |
           export VERBOSE_FLAG='${{ "--verbose" if args.verbose_mode else "" }}'

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -74,7 +74,7 @@
 
 ### Features
 
-* Add working-directory to the task, group and global scope ([#65](https://github.com/osl-incubator/makim/issues/65)) ([3fbd61e](https://github.com/osl-incubator/makim/commit/3fbd61efdefe22e29a53c8f0d46b6ef91bc55073))
+* Add dir to the task, group and global scope ([#65](https://github.com/osl-incubator/makim/issues/65)) ([3fbd61e](https://github.com/osl-incubator/makim/commit/3fbd61efdefe22e29a53c8f0d46b6ef91bc55073))
 
 ## [1.8.3](https://github.com/osl-incubator/makim/compare/1.8.2...1.8.3) (2023-08-15)
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,18 +1,18 @@
 # Features
 
-## Attribute: working-directory
+## Attribute: dir
 
-The working-directory feature in Makim allows users to define the directory from
-which commands associated with specific tasks or groups are executed. This
-provides greater flexibility and control over the execution environment.
+The dir feature in Makim allows users to define the directory from which
+commands associated with specific tasks or groups are executed. This provides
+greater flexibility and control over the execution environment.
 
-The `working-directory` attribute can be specified at three different scopes:
-global, group, and task. It allows users to set the working directory for a
-specific task, a group of tasks, or globally.
+The `dir` attribute can be specified at three different scopes: global, group,
+and task. It allows users to set the working directory for a specific task, a
+group of tasks, or globally.
 
 ### Syntax and Scopes
 
-The working-directory attribute can be applied to three different scopes:
+The dir attribute can be applied to three different scopes:
 
 - #### **Global Scope**
 
@@ -21,7 +21,7 @@ The working-directory attribute can be applied to three different scopes:
 
   ```yaml
   version: 1.0
-  working-directory: /path/to/global/directory
+  dir: /path/to/global/directory
   # ... other configuration ...
   ```
 
@@ -35,7 +35,7 @@ The working-directory attribute can be applied to three different scopes:
 
   groups:
     my-group:
-      working-directory: /path/to/group/directory
+      dir: /path/to/group/directory
       tasks:
         task-1:
           run: |
@@ -54,7 +54,7 @@ The working-directory attribute can be applied to three different scopes:
     my-group:
       tasks:
         my-task:
-          working-directory: /path/to/task/directory
+          dir: /path/to/task/directory
           run: |
           # This task will run with the working directory set to
           # /path/to/task/directory
@@ -64,22 +64,22 @@ The working-directory attribute can be applied to three different scopes:
 
 ```yaml
 version: 1.0
-working-directory: /project-root
+dir: /project-root
 
 groups:
   backend:
-    working-directory: backend
+    dir: backend
     tasks:
       build:
         help: Build the backend services
-        working-directory: services
+        dir: services
         run: |
           echo "Building backend services..."
           # Additional build commands specific to the backend
 
       test:
         help: Run backend tests
-        working-directory: tests
+        dir: tests
         run: |
           echo "Running backend tests..."
           # Additional test commands specific to the backend

--- a/docs/tutorials/introduction/.makim.yaml
+++ b/docs/tutorials/introduction/.makim.yaml
@@ -1,5 +1,5 @@
 version: 1.0
-working-directory: "/tmp"
+dir: "/tmp"
 
 groups:
   check-wd:

--- a/docs/tutorials/introduction/index.ipynb
+++ b/docs/tutorials/introduction/index.ipynb
@@ -904,7 +904,7 @@
    "source": [
     "%%writefile .makim.yaml\n",
     "version: 1.0\n",
-    "working-directory: \"/tmp\"\n",
+    "dir: \"/tmp\"\n",
     "\n",
     "groups:\n",
     "  check-wd:\n",

--- a/src/makim/core.py
+++ b/src/makim/core.py
@@ -256,17 +256,17 @@ class Makim:
 
         if scope_id >= SCOPE_GLOBAL:
             working_dir = update_working_directory(
-                working_dir, self.global_data.get('working-directory', '')
+                working_dir, self.global_data.get('dir', '')
             )
 
         if scope_id >= SCOPE_GROUP:
             working_dir = update_working_directory(
-                working_dir, self.group_data.get('working-directory', '')
+                working_dir, self.group_data.get('dir', '')
             )
 
         if scope_id == SCOPE_TARGET:
             working_dir = update_working_directory(
-                working_dir, self.task_data.get('working-directory', '')
+                working_dir, self.task_data.get('dir', '')
             )
 
         return working_dir

--- a/tests/smoke/.makim-dir-absolute-path.yaml
+++ b/tests/smoke/.makim-dir-absolute-path.yaml
@@ -1,5 +1,5 @@
 version: 1.0
-working-directory: "/tmp"
+dir: "/tmp"
 
 groups:
   setup:
@@ -23,30 +23,30 @@ groups:
           import os
           print(os.getcwd())
           assert os.getcwd() == "/tmp"
-          echo "working-directory-absolute-path [I] Done!"
+          echo "dir-absolute-path [I] Done!"
 
       task-absolute:
-        working-directory: "/tmp"
+        dir: "/tmp"
         help: Test global absolute path, group no path, task absolute path
         dependencies:
           - task: setup.folders
         run: |
           import os
           assert os.getcwd() == "/tmp"
-          echo "working-directory-absolute-path [II] Done!"
+          echo "dir-absolute-path [II] Done!"
 
       task-relative:
-        working-directory: "/tmp/group1/task4"
+        dir: "/tmp/group1/task4"
         help: est global absolute path, group no path, task relative path
         dependencies:
           - task: setup.folders
         run: |
           import os
           assert os.getcwd() == "/tmp/group1/task4"
-          echo "working-directory-absolute-path [III] Done!"
+          echo "dir-absolute-path [III] Done!"
 
   group-relative:
-    working-directory: "group1"
+    dir: "group1"
     tasks:
       task-no-path:
         help: Test global absolute path, group relative path, task no path
@@ -55,30 +55,30 @@ groups:
         run: |
           import os
           assert os.getcwd() == "/tmp/group1"
-          echo "working-directory-absolute-path [IV] Done!"
+          echo "dir-absolute-path [IV] Done!"
 
       task-absolute:
-        working-directory: "/tmp"
+        dir: "/tmp"
         help: Test global absolute path, group relative path, task absolute path
         dependencies:
           - task: setup.folders
         run: |
           import os
           assert os.getcwd() == "/tmp"
-          echo "working-directory-absolute-path [V] Done!"
+          echo "dir-absolute-path [V] Done!"
 
       task-relative:
-        working-directory: "task3"
+        dir: "task3"
         help: Test global absolute path, group relative path, task relative path
         dependencies:
           - task: setup.folders
         run: |
           import os
           assert os.getcwd() == "/tmp/group1/task3"
-          echo "working-directory-absolute-path [VI] Done!"
+          echo "dir-absolute-path [VI] Done!"
 
   group-absolute:
-    working-directory: "/tmp/group2"
+    dir: "/tmp/group2"
     tasks:
       task-no-path:
         help: Test global absolute path, group absolute path, task no path
@@ -87,20 +87,20 @@ groups:
         run: |
           import os
           assert os.getcwd() == "/tmp/group2"
-          echo "working-directory-absolute-path [VII] Done!"
+          echo "dir-absolute-path [VII] Done!"
 
       task-absolute:
-        working-directory: "/tmp"
+        dir: "/tmp"
         help: Test global absolute path, group absolute path, task absolute path
         dependencies:
           - task: setup.folders
         run: |
           import os
           assert os.getcwd() == "/tmp"
-          echo "working-directory-absolute-path [VIII] Done!"
+          echo "dir-absolute-path [VIII] Done!"
 
       task-relative:
-        working-directory: "task-relative"
+        dir: "task-relative"
         help: |
           Test global absolute path, group absolute path, task relative  path
         dependencies:
@@ -108,4 +108,4 @@ groups:
         run: |
           import os
           assert os.getcwd() == "/tmp/group2/task-relative"
-          echo "working-directory-absolute-path [IX] Done!"
+          echo "dir-absolute-path [IX] Done!"

--- a/tests/smoke/.makim-dir-no-path.yaml
+++ b/tests/smoke/.makim-dir-no-path.yaml
@@ -19,30 +19,30 @@ groups:
         run: |
           import os
           echo f"{os.getcwd()}"
-          echo "working-directory-no-path [I] Done!"
+          echo "dir-no-path [I] Done!"
 
       task-absolute:
-        working-directory: "/tmp/task1"
+        dir: "/tmp/task1"
         help: Test global no-path, group no-path, task absolute
         dependencies:
           - task: setup.create-folders
         run: |
           import os
           assert os.getcwd() == "/tmp/task1"
-          echo "working-directory-no-path [II] Done!"
+          echo "dir-no-path [II] Done!"
 
       task-relative:
-        working-directory: "task2"
+        dir: "task2"
         help: Test global no-path, group no-path, task relative
         dependencies:
           - task: setup.create-folders
         run: |
           import os
           assert os.getcwd() == "/tmp/task2"
-          echo "working-directory-no-path [III] Done!"
+          echo "dir-no-path [III] Done!"
 
   group-absolute:
-    working-directory: "/tmp/group-absolute"
+    dir: "/tmp/group-absolute"
     tasks:
       task-no-path:
         help: Test global no-path, group absolute path, task no-path
@@ -51,30 +51,30 @@ groups:
         run: |
           import os
           assert os.getcwd() == "/tmp/group-absolute"
-          echo "working-directory-no-path [IV] Done!"
+          echo "dir-no-path [IV] Done!"
 
       task-absolute:
-        working-directory: /tmp/task1
+        dir: /tmp/task1
         help: Test global no-path, group absolute path, task absolute path
         dependencies:
           - task: setup.create-folders
         run: |
           import os
           assert os.getcwd() == "/tmp/task1"
-          echo "working-directory-no-path [V] Done!"
+          echo "dir-no-path [V] Done!"
 
       task-relative:
-        working-directory: "task1"
+        dir: "task1"
         help: Test global no-path, group absolute path, task relative path
         dependencies:
           - task: setup.create-folders
         run: |
           import os
           assert os.getcwd() == "/tmp/group-absolute/task1"
-          echo "working-directory-no-path [VI] Done!"
+          echo "dir-no-path [VI] Done!"
 
   group-relative:
-    working-directory: "group-relative"
+    dir: "group-relative"
     tasks:
       task-no-path:
         help: Test global no-path, group relative path, task no-path
@@ -83,24 +83,24 @@ groups:
         run: |
           import os
           assert os.getcwd() == "/tmp/group-relative"
-          echo "working-directory-no-path [VII] Done!"
+          echo "dir-no-path [VII] Done!"
 
       task-absolute:
-        working-directory: "/tmp/task2"
+        dir: "/tmp/task2"
         help: Test global no-path, group relative path, task absolute path
         dependencies:
           - task: setup.create-folders
         run: |
           import os
           assert os.getcwd() == "/tmp/task2"
-          echo "working-directory-no-path [VIII] Done!"
+          echo "dir-no-path [VIII] Done!"
 
       task-relative:
-        working-directory: "task1"
+        dir: "task1"
         help: Test global no-path, group relative path, task relative path
         dependencies:
           - task: setup.create-folders
         run: |
           import os
           assert os.getcwd() == "/tmp/group-relative/task1"
-          echo "working-directory-no-path [IX] Done!"
+          echo "dir-no-path [IX] Done!"

--- a/tests/smoke/.makim-dir-relative-path.yaml
+++ b/tests/smoke/.makim-dir-relative-path.yaml
@@ -1,5 +1,5 @@
 version: 1.0
-working-directory: "global-relative"
+dir: "global-relative"
 
 groups:
   setup:
@@ -22,30 +22,30 @@ groups:
           import os
           print(os.getcwd())
           assert os.getcwd() == "/tmp/global-relative"
-          echo "working-directory-relative-path [I] Done!"
+          echo "dir-relative-path [I] Done!"
 
       task-absolute:
-        working-directory: "/tmp/global-relative/task1"
+        dir: "/tmp/global-relative/task1"
         help: Test global relative path, group no-path, task absolute path
         dependencies:
           - task: setup.create-folders
         run: |
           import os
           assert os.getcwd() == "/tmp/global-relative/task1"
-          echo "working-directory-relative-path [II] Done!"
+          echo "dir-relative-path [II] Done!"
 
       task-relative:
-        working-directory: "task2"
+        dir: "task2"
         help: Test global relative path, group no-path, task relative path
         dependencies:
           - task: setup.create-folders
         run: |
           import os
           assert os.getcwd() == "/tmp/global-relative/task2"
-          echo "working-directory-relative-path [III] Done!"
+          echo "dir-relative-path [III] Done!"
 
   group-absolute:
-    working-directory: "/tmp/global-relative/group-absolute"
+    dir: "/tmp/global-relative/group-absolute"
     tasks:
       task-no-path:
         help: Test global relative path, group absolute path, task no-path
@@ -54,10 +54,10 @@ groups:
         run: |
           import os
           assert os.getcwd() == "/tmp/global-relative/group-absolute"
-          echo "working-directory-relative-path [IV] Done!"
+          echo "dir-relative-path [IV] Done!"
 
       task-absolute:
-        working-directory: "/tmp/global-relative/task2"
+        dir: "/tmp/global-relative/task2"
         help: |
           Test global relative path, group absolute path, task absolute path
         dependencies:
@@ -65,10 +65,10 @@ groups:
         run: |
           import os
           assert os.getcwd() == "/tmp/global-relative/task2"
-          echo "working-directory-relative-path [V] Done!"
+          echo "dir-relative-path [V] Done!"
 
       task-relative:
-        working-directory: "task1"
+        dir: "task1"
         help: |
           Test global relative path, group absolute path, task relative path
         dependencies:
@@ -76,10 +76,10 @@ groups:
         run: |
           import os
           assert os.getcwd() == "/tmp/global-relative/group-absolute/task1"
-          echo "working-directory-relative-path [VI] Done!"
+          echo "dir-relative-path [VI] Done!"
 
   group-relative:
-    working-directory: "group-relative"
+    dir: "group-relative"
     tasks:
       task-no-path:
         help: Test global relative path, group relative path, task no-path
@@ -88,10 +88,10 @@ groups:
         run: |
           import os
           assert os.getcwd() == "/tmp/global-relative/group-relative"
-          echo "working-directory-relative-path [VII] Done!"
+          echo "dir-relative-path [VII] Done!"
 
       task-absolute:
-        working-directory: "/tmp/global-relative/task2"
+        dir: "/tmp/global-relative/task2"
         help: |
           Test global relative path, group absolute path, task absolute path
         dependencies:
@@ -99,10 +99,10 @@ groups:
         run: |
           import os
           assert os.getcwd() == "/tmp/global-relative/task2"
-          echo "working-directory-relative-path [VIII] Done!"
+          echo "dir-relative-path [VIII] Done!"
 
       task-relative:
-        working-directory: "task1"
+        dir: "task1"
         help: |
           Test global relative path, group absolute path, task relative path
         dependencies:
@@ -110,4 +110,4 @@ groups:
         run: |
           import os
           assert os.getcwd() == "/tmp/global-relative/group-relative/task1"
-          echo "working-directory-relative-path [IX] Done!"
+          echo "dir-relative-path [IX] Done!"


### PR DESCRIPTION
Rename the configuration attribute `working-directory` to `dir`. This will keep the configuration simpler.