### PR TITLE
Fix task names in hooks in .makim-scheduler.yaml

### DIFF
--- a/tests/smoke/.makim-scheduler.yaml
+++ b/tests/smoke/.makim-scheduler.yaml
@@ -17,9 +17,9 @@ groups:
       test-all:
         hooks:
           pre-run:
-            - task: test.test-echo  
-            - task: test.test-date  
-            - task: test.test-sleep  
+            - task: test.test-echo
+            - task: test.test-date
+            - task: test.test-sleep
 
 scheduler:
   test_basic_echo:

--- a/tests/smoke/.makim-scheduler.yaml
+++ b/tests/smoke/.makim-scheduler.yaml
@@ -17,9 +17,9 @@ groups:
       test-all:
         hooks:
           pre-run:
-            - task: test-echo
-            - task: test-date
-            - task: test-sleep
+            - task: test.test-echo  
+            - task: test.test-date  
+            - task: test.test-sleep  
 
 scheduler:
   test_basic_echo:


### PR DESCRIPTION
# Pull Request description

## Purpose  
This PR fixes incorrect task references in the `test-all` hooks by adding the missing `test.` group prefix, ensuring tasks are resolved correctly under the `test` group.

## Linked Issue  
This PR resolves #151 .  

## How to test these changes  
1. Run the smoke tests:  
```bash  
makim smoke-tests.scheduler  
```
2. Verify no "task not found" errors occur.

Verify no "task not found" errors occur.

Pull Request Checklists
This PR is a:

- [x] bug-fix
- [ ] new feature
- [ ] maintenance

### About this PR:
- [x] it includes tests.
- [x] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [x] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

### Author's Checklist:
- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more complexity.
- [x] New and old tests passed locally.