### PR TITLE
Fix mamba command doc

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -143,7 +143,7 @@ environment:
    `poetry` for managing Python dependencies.
 
    ```bash
-   $ mamba env create --file conda/dev.yaml --force
+   $ mamba env create --file conda/dev.yaml --yes
    $ conda activate makim
    $ poetry config virtualenvs.create false
    $ poetry install

--- a/tests/smoke/.makim-scheduler.yaml
+++ b/tests/smoke/.makim-scheduler.yaml
@@ -17,9 +17,9 @@ groups:
       test-all:
         hooks:
           pre-run:
-            - task: test-echo
-            - task: test-date
-            - task: test-sleep
+            - task: test.test-echo  
+            - task: test.test-date  
+            - task: test.test-sleep  
 
 scheduler:
   test_basic_echo:


### PR DESCRIPTION
# Update Mamba Environment Creation Command in CONTRIBUTING.md

## Description

The documentation in the CONTRIBUTING.md file currently instructs users to create a Mamba environment using an incorrect command. The existing command:

```bash
mamba env create --file conda/dev.yaml --force
```
results in the following error:
```bash
mamba: error: unrecognized arguments: --file conda/dev.yaml --force
```

The corrected command is:

```bash
mamba env create -file conda/dev.yaml --yes
```
This PR updates the documentation to reflect the correct usage.


Checklist
 - [x] I have reviewed the changes and confirmed they fix the command.
  - [x] I have tested the updated command locally.
 - [x]  The documentation in CONTRIBUTING.md has been updated accordingly.