### PR TITLE
Fix mamba command documentation

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -143,7 +143,7 @@ environment:
    `poetry` for managing Python dependencies.
 
    ```bash
-   $ mamba env create --file conda/dev.yaml --force
+   $ mamba env create --file conda/dev.yaml --yes
    $ conda activate makim
    $ poetry config virtualenvs.create false
    $ poetry install

--- a/src/makim/core.py
+++ b/src/makim/core.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, List, Optional, TypedDict, Union, cast
 import dotenv
 import paramiko
 import sh
-import yaml  # type: ignore
+import yaml
 
 from jinja2 import Environment
 from jsonschema import ValidationError, validate

--- a/src/makim/core.py
+++ b/src/makim/core.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, List, Optional, TypedDict, Union, cast
 import dotenv
 import paramiko
 import sh
-import yaml
+import yaml  # type: ignore
 
 from jinja2 import Environment
 from jsonschema import ValidationError, validate


### PR DESCRIPTION
## Description

The documentation in the CONTRIBUTING.md file currently instructs users to create a Mamba environment using an incorrect command. The existing command:

## Linked Issue  
This PR resolves #144  .  


```bash
mamba env create --file conda/dev.yaml --force
```
results in the following error:
```bash
mamba: error: unrecognized arguments: --file conda/dev.yaml --force
```

The corrected command is:

```bash
mamba env create -file conda/dev.yaml --yes
```
## Benefits
Accurate instructions in CONTRIBUTING.md help onboard new contributors quickly, allowing them to focus on coding rather than troubleshooting setup issues.


Checklist
 - [x] I have reviewed the changes and confirmed they fix the command.
  - [x] I have tested the updated command locally.
 - [x]  The documentation in CONTRIBUTING.md has been updated accordingly.