### PR TITLE
fix(core): enforce explicit group naming for tasks

### DIFF
--- a/src/makim/core.py
+++ b/src/makim/core.py
@@ -372,10 +372,14 @@ class Makim:
             )
 
     def _change_task(self, task_name: str) -> None:
-        group_name = 'default'
-        if '.' in task_name:
-            group_name, task_name = task_name.split('.')
+        if '.' not in task_name:
+            MakimLogs.raise_error(
+                f'Invalid task name "{task_name}". '
+                'Tasks must be defined with a group. Use "group.task-name".',
+                MakimError.MAKIM_TARGET_NOT_FOUND,
+            )
 
+        group_name, task_name = task_name.split('.', 1)
         self.task_name = task_name
         self._change_group_data(group_name)
 
@@ -395,9 +399,6 @@ class Makim:
 
         if group_name is not None:
             self.group_name = group_name
-
-        if self.group_name not in groups and len(groups) == 1:
-            self.group_name = next(iter(groups))
 
         for group in groups:
             if group == self.group_name:


### PR DESCRIPTION
## Pull Request description

<!-- Describe the purpose of your PR and the changes you have made. -->
This PR ensures that tasks must be explicitly referenced in the  
`group.task-name` format. If a task is provided without a group,  
makim will now raise an error instead of assuming a default group.  

<!-- Which issue this PR aims to resolve or fix? E.g.:
Solving issue #004
-->

resolves #168 

## How to test these changes

<!-- Example:

* run `$ abc -p 1234`
* open the web browser with url localhost:1234
* ...
-->

```yaml

groups:
  test:
    tasks:
      test-echo:
        run: echo "Basic echo test successful"

      test-all:
        hooks:
          pre-run:
            - task: test-echo
```
<img width="744" alt="Screenshot 2025-03-11 at 8 52 23 PM" src="https://github.com/user-attachments/assets/e26533cf-3252-4f57-b0d8-89cbc1f711aa" />


<!-- Modify the options to suit your project. -->

## Pull Request checklists

This PR is a:

- [x] bug-fix

About this PR:

- [x] it includes tests.
- [x] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [x] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more
      complexity.
- [x] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->

<!-- Add any other extra information that would help to understand the changes proposed by this PR -->

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
