### PR TITLE
feat: Implement failure hook to run tasks after a task fails

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -146,6 +146,9 @@ jobs:
       - name: Run smoke test for validating task conditionals
         run: makim smoke-tests.validate-conditionals
 
+      - name: Run smoke test for testing failure hook
+        run: makim smoke-tests.failure-hook
+
       - name: Semantic Release PR Title Check
         uses: osl-incubator/semantic-release-pr-title-check@v1.4.1
         if: success() || failure()

--- a/.makim.yaml
+++ b/.makim.yaml
@@ -93,6 +93,7 @@ groups:
             - task: smoke-tests.task-logger
             - task: smoke-tests.retry
             - task: smoke-tests.validate-conditionals
+            - task: smoke-tests.failure-hook
 
       ci:
         help: Run all tasks used on CI
@@ -555,6 +556,29 @@ groups:
           makim $VERBOSE_FLAG --file $MAKIM_FILE tests.test-wrong-group-vars
           makim $VERBOSE_FLAG --file $MAKIM_FILE tests.test-correct-task-vars
           makim $VERBOSE_FLAG --file $MAKIM_FILE tests.test-wrong-task-vars
+
+      failure-hook:
+        help: Test makim tasks with failure hook
+        args:
+          verbose-mode:
+            help: Run the all the tests in verbose mode
+            type: bool
+            action: store_true
+        env:
+          MAKIM_FILE: tests/smoke/.makim-failure-hook.yaml
+        backend: bash
+        hooks:
+          post-run:
+            - task: clean.tmp
+        run: |
+          export VERBOSE_FLAG='${{ "--verbose" if args.verbose_mode else "" }}'
+          makim $VERBOSE_FLAG --file $MAKIM_FILE --help
+          makim $VERBOSE_FLAG --file $MAKIM_FILE --version
+          makim $VERBOSE_FLAG --file $MAKIM_FILE tests.test-simple-failure
+          makim $VERBOSE_FLAG --file $MAKIM_FILE tests.test-failure-pass
+          makim $VERBOSE_FLAG --file $MAKIM_FILE tests.test-failure-retry
+          makim $VERBOSE_FLAG --file $MAKIM_FILE tests.test-failure-retry-once
+          makim $VERBOSE_FLAG --file $MAKIM_FILE tests.test-retry-pass
 
   error:
     help: This group helps tests failure tasks

--- a/src/makim/schema.json
+++ b/src/makim/schema.json
@@ -244,6 +244,32 @@
                             },
                             "additionalProperties": false
                           }
+                        },
+                        "failure": {
+                          "type": "array",
+                          "description": "Tasks to run if this task fails",
+                          "items": {
+                            "type": "object",
+                            "required": ["task"],
+                            "properties": {
+                              "task": {
+                                "type": "string",
+                                "description": "Name of the task to run."
+                              },
+                              "args": {
+                                "type": "object",
+                                "description": "Arguments to pass to the dependency task.",
+                                "additionalProperties": {
+                                  "type": ["string", "boolean"]
+                                }
+                              },
+                              "if": {
+                                "type": "string",
+                                "description": "Conditional expression to execute the task."
+                              }
+                            },
+                            "additionalProperties": false
+                          }
                         }
                       },
                       "additionalProperties": false

--- a/tests/smoke/.makim-failure-hook.yaml
+++ b/tests/smoke/.makim-failure-hook.yaml
@@ -1,0 +1,158 @@
+groups:
+  setup:
+    tasks:
+      post-hook:
+        help: Should run after task
+        log:
+          path: ./tests/smoke/logs/post_hook.txt
+        run: echo post
+
+      pre-hook:
+        help: Should run after task
+        log:
+          path: ./tests/smoke/logs/pre_hook.txt
+        run: echo pre
+
+      failure-hook:
+        help: Should run after task fails
+        log:
+          path: ./tests/smoke/logs/failure_hook.txt
+        run: echo fail
+
+      clean-failure-file:
+        help: This task removes failure log file
+        run: rm -f ./tests/smoke/logs/failure_hook.txt
+
+      clean-post-hook-file:
+        help: This task removes post hook log file
+        run: rm -f ./tests/smoke/logs/post_hook.txt
+
+      clean-pre-hook-file:
+        help: This task removes pre hook log file
+        run: rm -f ./tests/smoke/logs/pre_hook.txt
+
+  run:
+    tasks:
+      simple-failure:
+        help: This task will fail and run failure hook task
+        hooks:
+          failure:
+            - task: setup.failure-hook
+        run: |
+          assert 1 == 2
+
+      failure-pass:
+        help: This task will pass
+        hooks:
+          pre-run:
+            - task: setup.pre-hook
+          post-run:
+            - task: setup.post-hook
+          failure:
+            - task: setup.failure-hook
+        log:
+          path: ./tests/smoke/logs/failure_pass.txt
+        run: echo pass
+
+      failure-retry:
+        help: This task will fail and retry then run failure hook task
+        retry:
+          count: 2
+        hooks:
+          failure:
+            - task: setup.failure-hook
+        run: |
+          assert 1 == 2
+
+      failure-retry-once:
+        help: This task will only have one retry then will run failure hook task
+        retry:
+          count: 1
+        hooks:
+          failure:
+            - task: setup.failure-hook
+        run: |
+          assert 1 == 2
+
+      failure-retry-pass:
+        help: This task will have retry config but will pass
+        retry:
+          count: 3
+        hooks:
+          pre-run:
+            - task: setup.pre-hook
+          post-run:
+            - task: setup.post-hook
+          failure:
+            - task: setup.failure-hook
+        log:
+          path: ./tests/smoke/logs/failure_retry_pass.txt
+        run: echo "retry_pass"
+
+  tests:
+    tasks:
+      test-simple-failure:
+        help: This task will test simple failure task
+        hooks:
+          pre-run:
+            - task: setup.clean-failure-file
+            - task: run.simple-failure
+        run: |
+          import os
+          file_path = "./tests/smoke/logs/failure_hook.txt"
+          assert os.path.exists(file_path), f"Failure hook didn't run"
+
+      test-failure-pass:
+        help: This task will test failure pass
+        hooks:
+          pre-run:
+            - task: setup.clean-failure-file
+            - task: setup.clean-post-hook-file
+            - task: setup.clean-pre-hook-file
+            - task: run.failure-pass
+        run: |
+          import os
+          pre_file_path = "./tests/smoke/logs/post_hook.txt"
+          post_file_path = "./tests/smoke/logs/pre_hook.txt"
+          pass_file_path =  "./tests/smoke/logs/failure_pass.txt"
+
+          assert os.path.exists(pre_file_path), f"Pre run hook didn't run"
+          assert os.path.exists(post_file_path), f"Post run hook didn't run"
+          assert os.path.exists(pass_file_path), f"Failure pass didn't run"
+
+      test-failure-retry:
+        help: This task will test failure retry
+        hooks:
+          pre-run:
+            - task: run.failure-retry
+        run: |
+          import os
+          file_path = "./tests/smoke/logs/failure_hook.txt"
+          assert os.path.exists(file_path), f"Failure hook didn't run with retry"
+
+      test-failure-retry-once:
+        help: This task will test failure retry once
+        hooks:
+          pre-run:
+            - task: setup.clean-failure-file
+            - task: run.failure-retry-once
+        run: |
+          import os
+          file_path = "./tests/smoke/logs/failure_hook.txt"
+          assert os.path.exists(file_path), f"Failure hook didn't run with retry once"
+
+      test-retry-pass:
+        help: This task will test failure retry pass
+        hooks:
+          pre-run:
+            - task: setup.clean-failure-file
+            - task: run.failure-retry-pass
+        run: |
+          import os
+          pre_file_path = "./tests/smoke/logs/post_hook.txt"
+          post_file_path = "./tests/smoke/logs/pre_hook.txt"
+          pass_file_path =  "./tests/smoke/logs/failure_retry_pass.txt"
+
+          assert os.path.exists(pre_file_path), f"Pre run hook didn't run"
+          assert os.path.exists(post_file_path), f"Post run hook didn't run"
+          assert os.path.exists(pass_file_path), f"Failure retry pass didn't run"


### PR DESCRIPTION
## Pull Request description

This PR aims to implement the feature to define tasks to run after the task fails

<!-- Which issue this PR aims to resolve or fix? E.g.:
Solving issue #004
-->
resolves #18 

## How to test these changes

<!-- Example:

* run `$ abc -p 1234`
* open the web browser with url localhost:1234
* ...
-->
```yaml
tmp:
    tasks:
      echo:
        run: echo hello
      post:
        run: echo post
      test: 
        hooks:
          failure:
            - task: tmp.echo
          post-run:
            - task: tmp.post
        run: |
          assert 1==2
      new:
        run: echo next
```

```sh
makim smoke-tests.failure-hook
```

<!-- Modify the options to suit your project. -->

## Pull Request checklists

This PR is a:


- [x] new feature


About this PR:

- [x] it includes tests.
- [x] the tests are executed on CI.
- [x] the tests generate log file(s) (path).
- [x] pre-commit hooks were executed locally.
- [x] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more
      complexity.
- [x] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->

<!-- Add any other extra information that would help to understand the changes proposed by this PR -->

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
