### PR TITLE
fix: Resolve race condition in scheduler initialization (Error #19)

### DIFF
--- a/src/makim/scheduler.py
+++ b/src/makim/scheduler.py
@@ -217,13 +217,13 @@ class MakimScheduler:
         self.job_store_path = Path.home() / '.makim' / 'jobs.sqlite'
         self.job_history_path = Path.home() / '.makim' / 'history.json'
         self._setup_directories()
-        self._initialize_scheduler()
         self.job_history: dict[str, list[Dict[str, Any]]] = (
             self._load_history()
         )
 
         init_globals(self.config_file, self.job_history_path)
 
+        self._initialize_scheduler()
         self._sync_jobs_with_config(
             makim_instance.global_data.get('scheduler', {})
         )


### PR DESCRIPTION
### Description
This PR fixes a race condition where the scheduler worker starts processing pending jobs before the global configuration path is set. This was causing `Makim Error #19` (crash on startup) if there were overdue jobs in the database.

### Changes
- Swapped the initialization order in `MakimScheduler.__init__` to ensure `init_globals()` is called before `_initialize_scheduler()`.

### Verification
Reproduced the crash locally with pending jobs, applied the fix, and confirmed that the CLI now initializes correctly without crashing.

Solves #221 

cc: @xmnlab - Ready for review!